### PR TITLE
fix: require json objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,4 @@ A list of good things.
 
 Make a commit adding a line of JSON to [list.ndjson](./list.ndjson). The file format is [newline delimited json](http://ndjson.org/).
 
-Any value that's a JSON string will be interpreted as a generically 'good' CID.
-
-Make your entry a JSON object with a `"cid"` property to express what kind of goodness should be associated with the CID.
+Make your entry a JSON object with a `"cid"` property with the [CID](https://docs.ipfs.tech/concepts/content-addressing/) of the resource and a `"tags"` property  to express what kind of goodness should be associated with the CID.

--- a/list.ndjson
+++ b/list.ndjson
@@ -1,2 +1,1 @@
-"bafybeicaniz6j6bn2dgm3iln5cegevguhqftu7aefwjsz6mrgrhcdhkus4"
-{ "cid": "bafybeicaniz6j6bn2dgm3iln5cegevguhqftu7aefwjsz6mrgrhcdhkus4", tag: ["https://nftstorage.link/tags/bypass-default-csp"] }
+{ "cid": "bafybeicaniz6j6bn2dgm3iln5cegevguhqftu7aefwjsz6mrgrhcdhkus4", "tags": ["https://nftstorage.link/tags/bypass-default-csp"] }


### PR DESCRIPTION
Based on sync convo, let's require JSON objects with CID and tag on each entry of the list.

We should spec TAGs, but I feel like we can start with this for now and consider big picture once we have more use cases