### PR TITLE
Support Third Web default sites

### DIFF
--- a/list.ndjson
+++ b/list.ndjson
@@ -1,3 +1,4 @@
 { "cid": "bafybeicaniz6j6bn2dgm3iln5cegevguhqftu7aefwjsz6mrgrhcdhkus4", "tags": ["https://nftstorage.link/tags/bypass-default-csp"] }
 { "cid": "bafybeifmyraa2edobst7ld4dqvwvq4ful6cwrqxwml7jdujdmkrbocgoze", "tags": ["https://nftstorage.link/tags/bypass-default-csp", "https://w3s.link/tags/bypass-default-csp"] }
 { "cid": "bafybeieix4drjcwyz453ukrt6cg5gypueph76zrt4t6wdrzjr2jil2rtee", "tags": ["https://nftstorage.link/tags/bypass-default-csp", "https://w3s.link/tags/bypass-default-csp"] }
+{ "cid": "bafybeigvv5oe6vucvifseurryjtyblxzmwxnjvsoxzm5s62vfas26g7i7m", "tags": ["https://nftstorage.link/tags/bypass-default-csp", "https://w3s.link/tags/bypass-default-csp"] }


### PR DESCRIPTION
These are mint pages provided by https://thirdweb.com/ (suggested by an Avvy Domains user to me, these are not products that I am personally familiar with)

Here is the specific link that we are trying to get running: https://gateway.ipfscdn.io/ipfs/Qmcine1gpZUbQ73nk7ZGCcjKBVFYXrEtqrhujXk3HDQ6Nn/erc721.html?contract=0x3aB984c3438B8A7e19cAe8a62893BDFbED14113c&chainId=43114&theme=dark&primaryColor=yellow